### PR TITLE
General optimization and cleanup.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 Pillow
-click
 sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
 Pillow
-urllib3
 click
 sh

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
         'Click',
         'Pillow',
         'requests',
-        'urllib3',
         'sh',
     ],
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     version='0.1',
     py_modules=['xkcd'],
     install_requires=[
-        'Click',
         'Pillow',
         'requests',
         'sh',

--- a/xkcd.py
+++ b/xkcd.py
@@ -1,9 +1,7 @@
 import os
 import click
 import json
-import urllib.request
 import json
-import urllib
 from PIL import Image
 import requests
 from io import BytesIO
@@ -29,12 +27,13 @@ def cli(random):
         else:
             endpoint = "https://xkcd.com/info.0.json"
 
-        with urllib.request.urlopen(endpoint) as url:
-            data = json.loads(url.read().decode())
-            response = requests.get(data['img'])
-            img = Image.open(BytesIO(response.content))
+        with requests.Session() as s:
+            content = s.get(endpoint).content.decode()
+            data = json.loads(content)
+            res = s.get(data["img"])
+            img = Image.open(BytesIO(res.content))
             img.show()
 
-    except urllib.error.URLError:
+    except requests.ConnectionError:
         error_image = Image.open("assets/xkcd_404.jpg")
         error_image.show()

--- a/xkcd.py
+++ b/xkcd.py
@@ -22,20 +22,19 @@ def cli(random):
         print(lolcat(figlet("-c", "X K C D")))
     except ImportError:
         print("Welcome to xkcd Comics!")
-    rand_digits = str(randint(100, 999))
+    rand_digits = randint(100, 999)
     try:
         if random == 'random':
-            with urllib.request.urlopen("https://xkcd.com/" + rand_digits + "/info.0.json") as url:
-                data = json.loads(url.read().decode())
-                response = requests.get(data['img'])
-                img = Image.open(BytesIO(response.content))
-                img.show()
+            endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
         else:
-            with urllib.request.urlopen("https://xkcd.com/info.0.json") as url:
-                data = json.loads(url.read().decode())
-                response = requests.get(data['img'])
-                img = Image.open(BytesIO(response.content))
-                img.show()
+            endpoint = "https://xkcd.com/info.0.json"
+
+        with urllib.request.urlopen(endpoint) as url:
+            data = json.loads(url.read().decode())
+            response = requests.get(data['img'])
+            img = Image.open(BytesIO(response.content))
+            img.show()
+
     except urllib.error.URLError:
         error_image = Image.open("assets/xkcd_404.jpg")
         error_image.show()

--- a/xkcd.py
+++ b/xkcd.py
@@ -1,5 +1,5 @@
+import argparse
 import os
-import click
 import json
 import json
 from PIL import Image
@@ -7,9 +7,6 @@ import requests
 from io import BytesIO
 from random import randint
 
-
-@click.command()
-@click.option('--random', flag_value='random', default=False, help='Get Random Comic!')
 def cli(random):
     """XKCD Terminal Tool"""
     #click.echo('Hello World!')
@@ -22,7 +19,7 @@ def cli(random):
         print("Welcome to xkcd Comics!")
     rand_digits = randint(100, 999)
     try:
-        if random == 'random':
+        if random:
             endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
         else:
             endpoint = "https://xkcd.com/info.0.json"
@@ -37,3 +34,14 @@ def cli(random):
     except requests.ConnectionError:
         error_image = Image.open("assets/xkcd_404.jpg")
         error_image.show()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--random",
+        action="store_true",
+        help="Get a random comic."
+    )
+    args = parser.parse_args()
+    
+    cli(args.random)

--- a/xkcd.py
+++ b/xkcd.py
@@ -1,6 +1,4 @@
 import argparse
-import os
-import json
 import json
 from PIL import Image
 import requests
@@ -9,10 +7,8 @@ from random import randint
 
 def cli(random):
     """XKCD Terminal Tool"""
-    #click.echo('Hello World!')
-    # os.system('figlet -c "X K C D" | lolcat')
-    # print(random)
-    try:
+    
+	try:
         from sh import lolcat, figlet # Hacky fix for Build to pass system packages
         print(lolcat(figlet("-c", "X K C D")))
     except ImportError:

--- a/xkcd.py
+++ b/xkcd.py
@@ -15,9 +15,9 @@ def cli(random):
         print(lolcat(figlet("-c", "X K C D")))
     except ImportError:
         print("Welcome to xkcd Comics!")
-    rand_digits = randint(100, 999)
     try:
         if random:
+            rand_digits = randint(100, 999)
             endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
         else:
             endpoint = "https://xkcd.com/info.0.json"

--- a/xkcd.py
+++ b/xkcd.py
@@ -1,14 +1,16 @@
 import argparse
 import json
-from PIL import Image
 import requests
+
+from PIL import Image
 from io import BytesIO
 from random import randint
 
+
 def cli(random):
     """XKCD Terminal Tool"""
-    
-	try:
+ 
+    try:
         from sh import lolcat, figlet # Hacky fix for Build to pass system packages
         print(lolcat(figlet("-c", "X K C D")))
     except ImportError:

--- a/xkcd.py
+++ b/xkcd.py
@@ -15,6 +15,7 @@ def cli(random):
         print(lolcat(figlet("-c", "X K C D")))
     except ImportError:
         print("Welcome to xkcd Comics!")
+
     try:
         if random:
             rand_digits = randint(100, 999)
@@ -32,6 +33,7 @@ def cli(random):
     except requests.ConnectionError:
         error_image = Image.open("assets/xkcd_404.jpg")
         error_image.show()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
I saw no reason to use both `requests` and `urllib`, so I modified all http requests to use only the `requests` library.

In the `if random` block, I only change the endpoint that will be retrieved, and generate the random number if need be.
There is no need to repeat the `with` block twice.

I also changed the argument parser from `click` to `argparse` since `argparse` comes in the standard library and requires no installation.
It is ran like so: `python3 xkcd.py --random`

I also cleaned up unused, and duplicate imports, and stray comments.