### PR TITLE
Update xkcd.py

### DIFF
--- a/xkcd.py
+++ b/xkcd.py
@@ -16,7 +16,7 @@ def cli(random):
     except ImportError:
         print("Welcome to xkcd Comics!")
     try:
-        rand_digits = randint(100, 999)
+        rand_digits = randint(100, getLatestComicId())
         endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
 
         with requests.Session() as s:
@@ -27,5 +27,16 @@ def cli(random):
             img.show()
 
     except requests.ConnectionError:
+        # Possible XKCD api returned an invalid response for the info.0.json query
         error_image = Image.open("assets/xkcd_404.jpg")
         error_image.show()
+
+        
+def getLatestComicId():
+    try:
+        with requests.Session() as s:
+            content = s.get("https://xkcd.com/info.0.json").content.decode()
+            content = json.loads(content)
+            return int(content["num"])
+    except:
+        return None

--- a/xkcd.py
+++ b/xkcd.py
@@ -16,11 +16,8 @@ def cli(random):
     except ImportError:
         print("Welcome to xkcd Comics!")
     try:
-        if random == 'random':
-            rand_digits = randint(100, 999)
-            endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
-        else:
-            endpoint = "https://xkcd.com/info.0.json"
+        rand_digits = randint(100, 999)
+        endpoint = "https://xkcd.com/{}/info.0.json".format(rand_digits)
 
         with requests.Session() as s:
             content = s.get(endpoint).content.decode()


### PR DESCRIPTION
According to [this comment](https://github.com/itsron717/XKCD/issues/5#issuecomment-482522940) Even running `xkcd` without any args should get random comic. However, since XKCD's API (likely) has changed, the original `else` segment would always return a constant comic (in my case, `https://xkcd.com/2392/`)

Since (to my understanding) the `--random` flag was only there to *enforce* randomness (and not letting XKCD do the random selection) but the API has changed, this proposed change basically removes the if-else clause entirely, forcing a random comic every time. (And **basically ignoring the `--random` flag subsequentially** -- it's just there to maintain some sort of backward-compatibility, in case that would be used.)

Also improves code regarding randomization.